### PR TITLE
removed `n_files_tested` from the summary, to align the terminal verbose format

### DIFF
--- a/src/fixml/modules/workflow/parse.py
+++ b/src/fixml/modules/workflow/parse.py
@@ -102,7 +102,7 @@ class ResponseParser(ExportableMixin):
     def as_markdown(self, add_quarto_header: bool = False) -> str:
 
         score = self.get_completeness_score(score_format='fraction')
-        summary_df = self.evaluation_report[['ID', 'Title', 'is_Satisfied', 'n_files_tested']]
+        summary_df = self.evaluation_report[['ID', 'Title', 'is_Satisfied']]
 
         response = self.response
         call_results = response.call_results


### PR DESCRIPTION
We could quickly review and approve it, please