### PR TITLE
feat: Load Jinja template from external file location

### DIFF
--- a/src/fixml/modules/template.py
+++ b/src/fixml/modules/template.py
@@ -39,6 +39,11 @@ class TemplateLoader:
         validate_template : str, optional
             If provided, the external template source will be compared with the
             referred internal template to confirm all variables are present.
+
+        Returns
+        -------
+        jinja2.Template
+            Source file loaded as a Jinja2 Template.
         """
         with open(ext_template_path, "r") as f:
             source = f.read()

--- a/src/fixml/modules/template.py
+++ b/src/fixml/modules/template.py
@@ -44,8 +44,7 @@ class TemplateLoader:
             source = f.read()
 
         if validate_template:
-            ast = cls.env.parse(source)
-            vars_external = meta.find_undeclared_variables(ast)
+            vars_external = cls._get_vars_from_source(source)
             vars_internal = cls.list_vars_in_template(validate_template)
             diff = set(vars_internal).difference(vars_external)
             if diff:
@@ -56,6 +55,11 @@ class TemplateLoader:
         return Template(source)
 
     @classmethod
+    def _get_vars_from_source(cls, source: str) -> set[str]:
+        ast = cls.env.parse(source)
+        return meta.find_undeclared_variables(ast)
+
+    @classmethod
     def list(cls) -> list[str]:
         return cls.env.list_templates(extensions=cls.template_exts)
 
@@ -64,5 +68,4 @@ class TemplateLoader:
         """List all variables present in template."""
         template = cls.load(template_name)
         source = cls.env.loader.get_source(cls.env, template.name)[0]
-        ast = cls.env.parse(source)
-        return meta.find_undeclared_variables(ast)
+        return cls._get_vars_from_source(source)

--- a/src/fixml/modules/template.py
+++ b/src/fixml/modules/template.py
@@ -37,7 +37,7 @@ class TemplateLoader:
         ext_template_path : str or pathlib.Path
             Path to the external template file.
         validate_template : str, optional
-            If provided, the external template course will be compared with the
+            If provided, the external template source will be compared with the
             referred internal template to confirm all variables are present.
         """
         with open(ext_template_path, "r") as f:

--- a/src/fixml/modules/workflow/parse.py
+++ b/src/fixml/modules/workflow/parse.py
@@ -1,4 +1,5 @@
 from typing import Optional, Union
+from pathlib import Path
 
 import pandas as pd
 import os
@@ -6,18 +7,24 @@ import os
 from ..template import TemplateLoader
 from .response import EvaluationResponse
 from ..mixins import ExportableMixin
-from ..utils import get_extension
 
 
 class ResponseParser(ExportableMixin):
-    def __init__(self, response: EvaluationResponse):
+    def __init__(self, response: EvaluationResponse,
+                 export_template_path: Optional[Union[str, Path]] = None):
         super().__init__()
         self.response = response
         self.evaluation_report = None
         self.repository = self.response.repository.object
         self.git_context = self.repository.git_context
         self.items = []
-        self.export_template = TemplateLoader.load("evaluation")
+        if not export_template_path:
+            # use default template from package
+            self.export_template = TemplateLoader.load("evaluation")
+        else:
+            # load from external source, validate all vars are present
+            self.export_template = TemplateLoader.load_from_external(
+                export_template_path, "evaluation")
 
     def _parse_items(self):
         items = []

--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -1,0 +1,57 @@
+from importlib.resources import files
+
+import pytest
+from jinja2 import Template, TemplateNotFound
+from fixml.modules.template import TemplateLoader
+
+
+@pytest.mark.parametrize(
+    "template_name",
+    ["evaluation", "checklist", "eval_report.md.jinja", "checklist.md.jinja"]
+)
+def test_template_can_load(template_name):
+    t = TemplateLoader.load(template_name)
+    assert type(t) == Template
+
+
+@pytest.mark.parametrize(
+    "template_name",
+    ["evaluation123" "eval_report.md",
+     "./src/fixml/data/templates/checklist.md.jinja"]
+)
+def test_errors_will_return_when_no_templates_can_be_found(template_name):
+    with pytest.raises(TemplateNotFound):
+        t = TemplateLoader.load(template_name)
+
+
+def test_all_templates_can_be_listed():
+    template_data_dir = files("fixml.data.templates")
+    internal_templates = [x.name for x in template_data_dir.iterdir()]
+    assert internal_templates == TemplateLoader.list()
+
+
+@pytest.mark.parametrize(
+    "template_path, template_name",
+    [
+        ("./src/fixml/data/templates/checklist.md.jinja", "checklist"),
+        ("./src/fixml/data/templates/eval_report.md.jinja", "evaluation"),
+    ]
+)
+def test_templates_valid_themselves_when_loaded_externally(template_path,
+                                                           template_name):
+    TemplateLoader.load_from_external(template_path,
+                                      validate_template=template_name)
+
+
+@pytest.mark.parametrize(
+    "template_path, template_name",
+    [
+        ("README.md", "checklist"),
+        ("./src/fixml/data/templates/checklist.md.jinja", "evaluation"),
+    ]
+)
+def test_external_templates_fail_validation_when_vars_dont_match(template_path,
+                                                                 template_name):
+    with pytest.raises(ValueError):
+        TemplateLoader.load_from_external(template_path,
+                                          validate_template=template_name)

--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from importlib.resources import files
 
 import pytest
@@ -55,3 +56,16 @@ def test_external_templates_fail_validation_when_vars_dont_match(template_path,
     with pytest.raises(ValueError):
         TemplateLoader.load_from_external(template_path,
                                           validate_template=template_name)
+
+
+
+@pytest.mark.parametrize(
+    "template_path",
+    [
+        ("./src/fixml/data/templates/checklist.md.jinja"),
+        ("./src/fixml/data/templates/eval_report.md.jinja"),
+    ]
+)
+def test_external_template_have_full_file_path(template_path):
+    t = TemplateLoader.load_from_external(template_path)
+    assert t.filename == str(Path(template_path).resolve())


### PR DESCRIPTION
This PR:
- adds `TemplateLoader.load_from_external()` for loading external template with optional validation logic
- adds optional argument in ResponseParser to allow use of non-default template when exporting `EvaluationResponse`.
- adds tests for `TemplateLoader`
