### PR TITLE
hotfix: Add pandas' extra dependency; bump version to 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 <!--next-version-placeholder-->
 
+## v0.1.1 (26/06/2024)
+
+- Add missing optional requirement of pandas needed for exporting dataframe 
+  into markdown format.
+
 ## v0.1.0 (25/06/2024)
 
 - First release of `fixml`!

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,8 +10,8 @@ project = "fixml"
 copyright = "2024, John Shiu, Orix Au Yeung, Tony Shum, and Yingzi Jin"
 author = "John Shiu, Orix Au Yeung, Tony Shum, and Yingzi Jin"
 
-release = '0.1.0'
-version = '0.1.0'
+release = '0.1.1'
+version = '0.1.1'
 
 # -- General configuration ---------------------------------------------------
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2480,9 +2480,11 @@ files = [
 ]
 
 [package.dependencies]
+jinja2 = {version = ">=3.1.2", optional = true, markers = "extra == \"output-formatting\""}
 numpy = {version = ">=1.26.0", markers = "python_version >= \"3.12\""}
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
+tabulate = {version = ">=0.9.0", optional = true, markers = "extra == \"output-formatting\""}
 tzdata = ">=2022.7"
 
 [package.extras]
@@ -4671,4 +4673,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "9897b08606b1cb8eaf148ae5f670652bfe73f310317127275fa445071ae59342"
+content-hash = "73d2edd1c52db58fbb0b7743f5a3759e839666a57dea8fbd7585ebca2fd8ecd6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fixml"
-version = "0.1.0"
+version = "0.1.1"
 description = "Package for automated test evaluation and creation"
 authors = ["John Shiu, Orix Au Yeung, Tony Shum, Yingzi Jin"]
 license = "MIT"
@@ -10,7 +10,7 @@ include = ["src/fixml/data"]
 [tool.poetry.dependencies]
 python = "^3.12"
 fire = "^0.6.0"
-pandas = "^2.2.2"
+pandas = {extras = ["output-formatting"], version = "^2.2.2"}
 pypandoc = "^1.13"
 python-dotenv = "^1.0.1"
 ruamel-yaml = "^0.18.6"


### PR DESCRIPTION
This PR:
- Add missing optional requirement of `pandas` needed for exoprting dataframe into markdown format.
- Bump package version to 0.1.1.

Closes #209 .